### PR TITLE
Use NASA Grantee logo

### DIFF
--- a/src/Carina.vue
+++ b/src/Carina.vue
@@ -167,7 +167,7 @@
               ><img alt="SciAct Logo" src="https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/logo_sciact.png"
             /></a>
             <a href="https://nasa.gov/" target="_blank" rel="noopener noreferrer" class="pl-1"
-              ><img alt="SciAct Logo" src="https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/NASA_Partner_color_300_no_outline.png"
+              ><img alt="SciAct Logo" src="https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/NASA_Grantee_color_no_outline.png"
             /></a>
             <!-- <ShareNetwork
               v-for="network in networks"


### PR DESCRIPTION
As the title says, this updates the story to use the NASA Grantee logo rather than the NASA Partner one. This story predates the toolkit component, so the update here is directly in the main story component itself.