### PR TITLE
Bump Node.js version in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.17.1'
+          node-version: '18.20.0'
 
       - name: Yarn install
         run: yarn install


### PR DESCRIPTION
This PR bumps our version of Node.js used in the GitHub Actions workflow.